### PR TITLE
use correct TL_SCRIPT

### DIFF
--- a/module/public/popup.php
+++ b/module/public/popup.php
@@ -14,7 +14,7 @@
  * Initialize the system
  */
 define('TL_MODE', 'BE');
-define('TL_SCRIPT', 'system/modules/iconwizard/public/popup.php');
+define('TL_SCRIPT', 'system/modules/icon-wizard/public/popup.php');
 
 // Contao 3.
 $file = dirname(dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])))) . '/initialize.php';


### PR DESCRIPTION
This might fix #11.

Explanation: the extension is installed into `system/modules/icon-wizard` (see [composer.json](https://github.com/netzmacht/contao-icon-wizard/blob/1.2.2/composer.json#L45)). However within the [popup.php](https://github.com/netzmacht/contao-icon-wizard/blob/1.2.2/module/public/popup.php#L17) you define the `TL_SCRIPT` constant as
```php
define('TL_SCRIPT', 'system/modules/iconwizard/public/popup.php');
```
i.e. without the dash (`-`) within the module's folder. This results in a wrong base URL.